### PR TITLE
added maxsplit=1 to split on first instance of equal sign

### DIFF
--- a/desktop_parser/desktop.py
+++ b/desktop_parser/desktop.py
@@ -59,7 +59,7 @@ class DesktopFile:
                             self.data[key] = {localekey: line.split("=")[1]}
                     continue
                 if "=" in line:
-                    key, value = line.split("=")
+                    key, value = line.split("=", 1)
                     if issection:
                         self.data[section][key] = value
                     else:


### PR DESCRIPTION
_load() attempts to split based on any instance of the equal sign in a line, which isn't ideal...